### PR TITLE
chore: add syntax highlighting to nomad/job files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.job linguist-language=HCL


### PR DESCRIPTION
I have discovered that there is no syntax highlighting while browsing your repo on Github, this should help with that. 🎉 

https://github.com/github-linguist/linguist/tree/master/samples/HCL