### PR TITLE
feat(radbot): ai-intel wiki mount + MCP bridge env vars

### DIFF
--- a/.github/workflows/nomad.yaml
+++ b/.github/workflows/nomad.yaml
@@ -184,6 +184,7 @@ jobs:
         NOMAD_VAR_ingress_ip: ${{ secrets.NOMAD_VAR_ingress_ip }}
         NOMAD_VAR_radbot_credential_key: ${{ secrets.NOMAD_VAR_radbot_credential_key }}
         NOMAD_VAR_radbot_admin_token: ${{ secrets.NOMAD_VAR_radbot_admin_token }}
+        NOMAD_VAR_radbot_mcp_token: ${{ secrets.NOMAD_VAR_radbot_mcp_token }}
         NOMAD_VAR_mullvad_wireguard_key: ${{ secrets.NOMAD_VAR_mullvad_wireguard_key }}
         NOMAD_VAR_mullvad_wireguard_addr: ${{ secrets.NOMAD_VAR_mullvad_wireguard_addr }}
         NOMAD_VAR_sonarr_api_key: ${{ secrets.NOMAD_VAR_sonarr_api_key }}

--- a/nomad_jobs/ai-ml/radbot/nomad.job
+++ b/nomad_jobs/ai-ml/radbot/nomad.job
@@ -47,17 +47,24 @@ job "radbot" {
         ports       = ["http"]
         volumes     = [
           "local/config.yaml:/app/config.yaml",
+          "${var.shared_dir}ai-intel:/mnt/ai-intel",
         ]
       }
 
       # Bootstrap-only env vars:
       # - RADBOT_CREDENTIAL_KEY: decrypt credentials/config stored in the DB
       # - RADBOT_ADMIN_TOKEN:    access /admin/ to manage everything else
+      # - RADBOT_MCP_TOKEN:      bootstrap bearer for MCP bridge HTTP
+      #                          (credential-store `mcp_token` wins once set)
+      # - RADBOT_WIKI_PATH:      wiki root inside the container (matches the
+      #                          ai-intel bind mount above)
       # All other config (API keys, models, integrations, endpoints) is stored
       # encrypted in the radbot_credentials table and managed via /admin/ UI.
       env {
         RADBOT_CREDENTIAL_KEY = var.radbot_credential_key
         RADBOT_ADMIN_TOKEN    = var.radbot_admin_token
+        RADBOT_MCP_TOKEN      = var.radbot_mcp_token
+        RADBOT_WIKI_PATH      = "/mnt/ai-intel"
         RADBOT_CONFIG_FILE    = "/app/config.yaml"
       }
 
@@ -128,4 +135,14 @@ variable "radbot_credential_key" {
 variable "radbot_admin_token" {
   type        = string
   description = "Bearer token for /admin/ — the only pre-shared secret"
+}
+
+variable "radbot_mcp_token" {
+  type        = string
+  description = "Bootstrap bearer token for the MCP bridge HTTP transport. The credential-store entry `mcp_token` takes priority once set, so this is only used before the first rotate."
+}
+
+variable "shared_dir" {
+  type        = string
+  description = "Base path on shared-mount nodes; jobs append their subdir (e.g. `${var.shared_dir}ai-intel`)."
 }


### PR DESCRIPTION
## Summary

Supports the radbot MCP bridge (perrymanuk/radbot#28). Two Nomad-side changes:

- Bind-mount `\${var.shared_dir}ai-intel` at `/mnt/ai-intel` inside the radbot container so the MCP bridge's `wiki_*` tools can read/write the shared ai-intel Obsidian vault
- New bootstrap env vars `RADBOT_MCP_TOKEN` (bearer for MCP HTTP; credential-store value wins once rotated from the admin UI) and `RADBOT_WIKI_PATH=/mnt/ai-intel` (explicit, self-documenting)
- Corresponding wiring in `.github/workflows/nomad.yaml` (`NOMAD_VAR_radbot_mcp_token`)

Merge this together with the radbot PR so the job has the new mount when the app starts expecting it.

## Prerequisite (operator action)

Before first deploy after merge: add a `NOMAD_VAR_radbot_mcp_token` GitHub secret to this repo. Generate any long random string — it's only the first-boot value. Once the admin UI rotates it, the credential-store value takes priority and the env var is effectively unused.

## Test plan

- [ ] `nomad job plan` shows only the expected diff (volume + env vars + vars)
- [ ] After deploy, `radbot.demonsafe.com/api/mcp/status` shows `wiki_mounted: true`
- [ ] Rotating the token in admin UI does not require a redeploy — clients using the new token are immediately accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)