### PR TITLE
fix(radbot): HCL rejects var interpolation in variable descriptions

### DIFF
--- a/nomad_jobs/ai-ml/radbot/nomad.job
+++ b/nomad_jobs/ai-ml/radbot/nomad.job
@@ -144,5 +144,5 @@ variable "radbot_mcp_token" {
 
 variable "shared_dir" {
   type        = string
-  description = "Base path on shared-mount nodes; jobs append their subdir (e.g. `${var.shared_dir}ai-intel`)."
+  description = "Base path on shared-mount nodes; jobs append their own subdirectory (this job mounts <shared_dir>/ai-intel at /mnt/ai-intel)."
 }


### PR DESCRIPTION
## Summary

Yesterday's #892 introduced a \`variable \"shared_dir\"\` block whose description string contained \`\${var.shared_dir}\` as an illustrative example. HCL disallows variable references inside variable description strings:

\`\`\`
nomad.job:147,85-88: Variables not allowed; Variables may not be used here.
nomad.job:147,18-83: Unsuitable value type; Unsuitable value: value must be known
\`\`\`

The deploy step in \`.github/workflows/nomad.yaml\` failed on \`nomad job run\` parse. Because the workflow uses a matrix-of-jobs pattern, the overall run still reported success, but the radbot task never rolled to v0.104 — \`radbot.demonsafe.com\` is still serving the pre-MCP-bridge image.

## Fix

Rephrase the description to plain prose with no interpolation syntax:

\`\`\`diff
-  description = "Base path on shared-mount nodes; jobs append their subdir (e.g. \`\${var.shared_dir}ai-intel\`)."
+  description = "Base path on shared-mount nodes; jobs append their own subdirectory (this job mounts <shared_dir>/ai-intel at /mnt/ai-intel)."
\`\`\`

Same information, no interpolation.

## After merge

The nomad.yaml deploy workflow will run on master and finally place v0.104. Verify with:

\`\`\`
curl -I https://radbot.demonsafe.com/setup/claude-code.md    # expect 200
curl -I https://radbot.demonsafe.com/mcp/sse                  # expect 401 or SSE stream (not 404)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)